### PR TITLE
Add method to clear messages already saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [1.1.2] - 2018-04-19 12:57 GMT
+- Add function clear for remove all toast messages saved in memory
+
 ## [1.1.1] - 2018-04-10 12:21 GMT
 ##### Added
 - Add package discovery to `composer.json` for Laravel 5.5 (see [#5], thanks @piperone).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## [1.1.2] - 2018-04-19 12:57 GMT
-- Add function clear for remove all toast messages saved in memory
+## [1.1.2] - 2018-09-19 12:57 GMT
+#### Added
+- Add function `clear()` to remove all pending toast messages from the session (see [#9], thanks @tiagozini).
 
 ## [1.1.1] - 2018-04-10 12:21 GMT
 ##### Added
@@ -24,7 +25,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [#4]: https://github.com/Grimthorr/laravel-toast/pull/4
 [#5]: https://github.com/Grimthorr/laravel-toast/pull/5
 [#7]: https://github.com/Grimthorr/laravel-toast/pull/7
+[#9]: https://github.com/Grimthorr/laravel-toast/pull/9
 
+[1.1.2]: https://github.com/Grimthorr/laravel-toast/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/Grimthorr/laravel-toast/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/Grimthorr/laravel-toast/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/Grimthorr/laravel-toast/tree/1.0.0

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ toast()->warning('message', 'title');
 ```
 Add a toast with the `warning` level.
 
-
 #### Clear
 ```php
 Toast::clear();
 ```
-Remove all toast messages saved in memory.
+Remove all pending toast messages from the session.
+
 
 ## Example
 These examples are using the default configuration.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Simple toast messages for Laravel 5.
     'Toast' => 'Grimthorr\LaravelToast\Facade',
   ),
   ```
-  
+
 **3.** Include `@include('toast::messages')` or `@include('toast::messages-jquery')` somewhere in your template.
 
 **4.** *Optional*: Run `php artisan vendor:publish --provider="Grimthorr\LaravelToast\ServiceProvider" --tag="config"` to publish the config file.
@@ -59,7 +59,7 @@ This package includes a couple of views to get you started, they can be publishe
   @foreach(Session::get('toasts') as $toast)
     <div class="alert alert-{{ $toast['level'] }}">
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-      
+
       {{ $toast['message'] }}
     </div>
   @endforeach
@@ -106,6 +106,12 @@ toast()->warning('message', 'title');
 ```
 Add a toast with the `warning` level.
 
+
+#### Clear
+```php
+Toast::clear();
+```
+Remove all toast messages saved in memory.
 
 ## Example
 These examples are using the default configuration.

--- a/src/Toast.php
+++ b/src/Toast.php
@@ -7,7 +7,7 @@ class Toast {
 
     /**
      * The current toasts
-     * 
+     *
      * @var array
      */
     protected $toasts = [];
@@ -127,5 +127,18 @@ class Toast {
 
         return $this;
     }
+
+    /**
+     * Clear toast messages arrays.
+     *
+     * @return $this
+     */
+    public function clear()
+    {
+        $this->toasts = [];
+
+        return $this;
+    }
+
 
 }

--- a/src/Toast.php
+++ b/src/Toast.php
@@ -6,7 +6,7 @@ namespace Grimthorr\LaravelToast;
 class Toast {
 
     /**
-     * The current toasts
+     * The current toasts.
      *
      * @var array
      */
@@ -123,22 +123,33 @@ class Toast {
             'level' => $level,
             'title' => $title,
         ]);
-        session()->flash('toasts', $this->toasts);
+        $this->flash();
 
         return $this;
     }
 
     /**
-     * Clear toast messages arrays.
+     * Clear all pending toasts from the session.
      *
      * @return $this
      */
     public function clear()
     {
         $this->toasts = [];
+        $this->flash();
 
         return $this;
     }
 
+    
+    /**
+     * Internal function to flash the session with the pending toasts.
+     *
+     * @return void
+     */
+    private function flash()
+    {
+        session()->flash('toasts', $this->toasts);
+    }
 
 }


### PR DESCRIPTION
The motivation for this issue were the bugs when I am tring to test the present or absence of toast messages in the page using phpunit. For some reason the navegation of unit test not really ocurr by complete using phpunit basic solution and because of it the messages stack of toast is never really cleaned by a new page load. Considering this I need clear this stack at each new page context in my phpunit tests.

I created a composer project (https://packagist.org/packages/tiagozini/laravel-toast) that I will remove when the merge request has been accepted.
